### PR TITLE
fix huggingface batch inference by explicitly specify batch inference batch size

### DIFF
--- a/uniflow/model/server.py
+++ b/uniflow/model/server.py
@@ -193,6 +193,8 @@ class HuggingfaceModelServer(AbsModelServer):
             load_in_4bit=True,
         )
 
+        # explicitly set batch_size for pipeline
+        # for batch inference.
         self._pipeline = pipeline(
             "text-generation",
             model=model,
@@ -203,6 +205,7 @@ class HuggingfaceModelServer(AbsModelServer):
             repetition_penalty=1.2,
             eos_token_id=tokenizer.eos_token_id,
             pad_token_id=tokenizer.pad_token_id,
+            batch_size=self._model_config.batch_size,
         )
 
     def _preprocess(self, data: List[str]) -> List[str]:


### PR DESCRIPTION
Fix batch inference. 

batch 8:
100%|██████████| 10/10 [00:35<00:00,  3.56s/it]
batch 4:
100%|██████████| 20/20 [01:01<00:00,  3.08s/it]
batch 2:
100%|██████████| 40/40 [01:11<00:00,  1.79s/it]
batch 1:
100%|██████████| 80/80 [01:12<00:00,  1.10it/s]

one caveat for my test is that I am using the exactly same length for each datapoint in a batch. If you are using different input size, it will slow down the batch inference due to padding.