### PR TITLE
remove line length and make black and isort check only and throw error

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,14 +35,14 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Format code with Black
       run: |
-        black . --line-length=127 --exclude=""
+        black . --exclude="" --check
     - name: Sort imports with isort
       run: |
-        isort . --line-length=127 --profile=black
+        isort . --profile=black --check-only
     - name: Test with unittest
       run: |
         poetry run python -m unittest discover

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,4 +1,5 @@
 import unittest
+
 from uniflow.node import Node
 
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,5 @@
 import unittest
+
 from uniflow.node import Node
 from uniflow.viz import Viz
 


### PR DESCRIPTION
- remove line-length=127 arguments for black, isort, and flake8
- add --check and --check-only to black and isort commands