### PR TITLE
Fix HuggingFace rater json object which already return the response in json dict, so no need to json.loads

### DIFF
--- a/uniflow/flow/rater/rater_flow.py
+++ b/uniflow/flow/rater/rater_flow.py
@@ -32,12 +32,6 @@ class RaterFlow(Flow):
         if (
             "response_format" in model_config
             and model_config["response_format"]["type"] == "json_object"  # noqa: W503
-            # TODO: This is a quick and dirty fix that JsonFormattedLLMRater
-            # is only for OpenAI model to return json string and use load to
-            # load into json object. For other model, it must use LLMRater
-            # for Huggingface model, it further support json_object by manually parse
-            # the response into json format while not relying on the model.
-            and "openai" in model_config["model_server"].lower()  # noqa: W503
         ):
             model = JsonFormattedLLMRater(
                 prompt_template=prompt_template,

--- a/uniflow/op/model/llm_processor.py
+++ b/uniflow/op/model/llm_processor.py
@@ -107,7 +107,10 @@ class JsonFormattedDataProcessor(AbsLLMProcessor):
 
         for d in data:
             try:
-                output_list.append(json.loads(d))
+                print(isinstance(d, dict))
+                # this is a quick and dirty fix because huggingface model server
+                # might already return the response in json format
+                output_list.append(d if isinstance(d, dict) else json.loads(d))
             except json.JSONDecodeError as e:
                 error_count += 1
                 error_list.append(str(e))

--- a/uniflow/op/model/llm_processor.py
+++ b/uniflow/op/model/llm_processor.py
@@ -107,7 +107,6 @@ class JsonFormattedDataProcessor(AbsLLMProcessor):
 
         for d in data:
             try:
-                print(isinstance(d, dict))
                 # this is a quick and dirty fix because huggingface model server
                 # might already return the response in json format
                 output_list.append(d if isinstance(d, dict) else json.loads(d))


### PR DESCRIPTION
- revert https://github.com/CambioML/uniflow/pull/116
- add a check regarding whether return object is already in json or not.