### PR TITLE
Add HuggingfaceJsonFormattedLLMRater to use LLMDataProcessor as base …

### DIFF
--- a/uniflow/flow/rater/rater_flow.py
+++ b/uniflow/flow/rater/rater_flow.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, Sequence
 from uniflow.constants import RATER
 from uniflow.flow.flow import Flow
 from uniflow.node import Node
-from uniflow.op.model.llm_rater import JsonFormattedLLMRater, LLMRater
+from uniflow.op.model.llm_rater import (
+    HuggingfaceJsonFormattedLLMRater,
+    LLMRater,
+    OpenAIJsonFormattedLLMRater,
+)
 from uniflow.op.model.model_op import ModelOp
 from uniflow.op.prompt import PromptTemplate
 
@@ -29,15 +33,22 @@ class RaterFlow(Flow):
             label2score (Dict[str, float]): String to score mapping.
         """
         super().__init__()
-        if (
-            "response_format" in model_config
-            and model_config["response_format"]["type"] == "json_object"  # noqa: W503
-        ):
-            model = JsonFormattedLLMRater(
-                prompt_template=prompt_template,
-                model_config=model_config,
-                label2score=label2score,
-            )
+        if model_config["response_format"]["type"] == "json_object":
+            if "openai" in model_config["model_server"].lower():
+                model = OpenAIJsonFormattedLLMRater(
+                    prompt_template=prompt_template,
+                    model_config=model_config,
+                    label2score=label2score,
+                )
+            else:
+                # Huggingface json formatted LLM rater
+                # will format the response into a json object
+                # after the response is returned from the model server.
+                model = HuggingfaceJsonFormattedLLMRater(
+                    prompt_template=prompt_template,
+                    model_config=model_config,
+                    label2score=label2score,
+                )
         else:
             model = LLMRater(
                 prompt_template=prompt_template,


### PR DESCRIPTION
Add HuggingfaceJsonFormattedLLMRater to use LLMDataProcessor as base class
- Added `HuggingfaceJsonFormattedLLMRater(LLMDataProcessor)` class to inherit LLMDataProcessor for HuggingFace model server
- It will use LLMDataProcessor to format string dict into string separated by colon for better HuggingFace model IF performance.
- HuggingFace model server in `json_object` model will put the response into json format.
- During `_deserialize`, it will calculate majority vote for self consistency and average score using the json dict.