### PR TITLE
Remove Ops name check

### DIFF
--- a/tests/op/test_op.py
+++ b/tests/op/test_op.py
@@ -1,7 +1,6 @@
 import unittest
 from typing import Sequence
 
-import uniflow.op.utils as utils
 from uniflow.node import Node
 from uniflow.op.op import Op
 
@@ -22,16 +21,6 @@ class TestOp(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.op._scope_name, self.op_name)
         self.assertEqual(self.op._count, 0)
-        self.assertIn(self.op_name, utils.OPS_NAME)
-
-        # TODO: fix 'test_op' KeyError on __del__
-        # with self.assertRaises(ValueError):
-        #     DummyOp(self.op_name)
-
-    def test_del(self):
-        self.assertIn(self.op_name, utils.OPS_NAME)
-        del self.op
-        self.assertNotIn(self.op_name, utils.OPS_NAME)
 
     def test_clear_count(self):
         self.op._count = 10

--- a/uniflow/op/op.py
+++ b/uniflow/op/op.py
@@ -37,13 +37,6 @@ class Op(abc.ABC):
         """
         self._scope_name = utils.get_op_scope_name(name)
         self._count = 0
-        if self._scope_name in utils.OPS_NAME:
-            raise ValueError(f"{self._scope_name} already exists.")
-        utils.OPS_NAME.add(self._scope_name)
-
-    def __del__(self) -> None:
-        """Destructor of op class for uniflow."""
-        utils.OPS_NAME.remove(self._scope_name)
 
     def clear_count(self) -> None:
         """Clear count of the op."""

--- a/uniflow/op/utils.py
+++ b/uniflow/op/utils.py
@@ -2,16 +2,10 @@
 import logging
 import os
 
-OPS_NAME = set()
 OPS_SCOPE = []
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def clear_ops_name():
-    """Clear ops name."""
-    OPS_NAME.clear()
 
 
 def get_op_scope_name(name: str) -> str:


### PR DESCRIPTION
This is a design mistake to include `Ops` name. Instead, we only need to keep unique node name to show the computational graph through graphviz.