### PR TITLE
Fix check key in Pydantic BaseModel class bug

### DIFF
--- a/uniflow/op/model/model_server.py
+++ b/uniflow/op/model/model_server.py
@@ -98,7 +98,10 @@ class AbsModelServer:
         self._model_config = model_config
         self._example_keys = None
 
-        if "few_shot_prompt" in prompt_template and prompt_template.few_shot_prompt:
+        if (
+            "few_shot_prompt" in prompt_template.model_fields
+            and prompt_template.few_shot_prompt  # noqa: W503
+        ):
             self._example_keys = list(
                 prompt_template.few_shot_prompt[0].model_dump().keys()
             )


### PR DESCRIPTION
Fix bug introduce by https://github.com/CambioML/uniflow/pull/136/files. In order to check whether key is in a Pydantic BaseModel, we need to use 

```
"few_shot_prompt" in prompt_template.model_fields
```

instead of 
```
"few_shot_prompt" in prompt_template
```

"few_shot_prompt" in prompt_template will always return `false`.

@SayaZhang 


